### PR TITLE
Notify only if window is not in focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Just like `undistract-me`, this notifies you when a long running command completes, but for zsh.
 
 ## Installation
-Just source notifyosd.zsh in your `~.zshrc`:
+Just source `notifyosd.zsh` in your `~.zshrc`:
 
 ```
 source path/to/notifyosd.zsh
@@ -18,6 +18,3 @@ Configuration is done with environment variables:
 * `LONG_RUNNING_IGNORE_LIST`: is a list of command that will be ignored by the script
 
 Note that a notification appears only if the terminal where the long command was running is not in focus.
-
-
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configuration is done with environment variables:
 * `UDM_PLAY_SOUND`: need to be set to a non zero value to play sound together with the notification
 * `NOTIFYOSD_HUMAN`: defines if human readable format should be adopted for the command duration, default is true, but
   can be disabled by setting this variable to `0`.
-* `LONG_RUNNING_IGNORE_LIST`: is a list of command that will be ignored by the script
+* `LONG_RUNNING_IGNORE_LIST`: is a shell array of command that will be ignored by the script
 
 Note that a notification appears only if the terminal where the long command was running is not in focus.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ source path/to/notifyosd.zsh
 ```
 
 ## Usage
+
 Configuration is done with environment variables:
 * `LONG_RUNNING_COMMAND_TIMEOUT`: to change the timeout, the default being 10s
 * `UDM_PLAY_SOUND`: need to be set to a non zero value to play sound together with the notification
@@ -18,3 +19,7 @@ Configuration is done with environment variables:
 * `LONG_RUNNING_IGNORE_LIST`: is a list of command that will be ignored by the script
 
 Note that a notification appears only if the terminal where the long command was running is not in focus.
+
+## Sounds support
+
+On Debian, you will need those packages installed: sox gnome-control-center-data

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Just like `undistract-me`, this notifies you when a long running command completes, but for zsh.
 
 ## Installation
-Just source `notifyosd.zsh` in your `~.zshrc`:
+Just source `notifyosd.zsh` in your `~/.zshrc`:
 
 ```
 source path/to/notifyosd.zsh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# notifyosd.zsh
+
+Just like `undistract-me`, this notifies you when a long running command completes, but for zsh.
+
+## Installation
+Just source notifyosd.zsh in your .zshrc:
+
+```
+source path/to/notifyosd.zsh
+```
+
+## Usage
+The default timeout is set to 10s, this can be changed via the environment variable `NOTIFYOST_LONG_RUNNING_COMMAND_TIMEOUT`
+
+Sound can be played on notification by setting `NOTIFYOSD_SOUND` to 1.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -3,17 +3,21 @@
 Just like `undistract-me`, this notifies you when a long running command completes, but for zsh.
 
 ## Installation
-Just source notifyosd.zsh in your .zshrc:
+Just source notifyosd.zsh in your `~.zshrc`:
 
 ```
 source path/to/notifyosd.zsh
 ```
 
 ## Usage
-The default timeout is set to 10s, this can be changed via the environment variable `NOTIFYOST_LONG_RUNNING_COMMAND_TIMEOUT`
+Configuration is done with environment variables:
+* `LONG_RUNNING_COMMAND_TIMEOUT`: to change the timeout, the default being 10s
+* `UDM_PLAY_SOUND`: need to be set to a non zero value to play sound together with the notification
+* `NOTIFYOSD_HUMAN`: defines if human readable format should be adopted for the command duration, default is true, but
+  can be disabled by setting this variable to `0`.
+* `LONG_RUNNING_IGNORE_LIST`: is a list of command that will be ignored by the script
 
-Sound can be played on notification by setting `NOTIFYOSD_SOUND` to 1.
-
+Note that a notification appears only if the terminal where the long command was running is not in focus.
 
 
 

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -19,7 +19,7 @@ function active_tmux_window() {
         echo notmux
         return 1
     }
-    tmux display-message -p '#W'
+    tmux display-message -p '#{window_name}'
 }
 
 function active_tmux_session() {
@@ -27,7 +27,7 @@ function active_tmux_session() {
         echo notmux
         return 1
     }
-    tmux display-message -p '#S'
+    tmux display-message -p '#{session_name}'
 }
 
 # Function taken from undistract-me, get the current window id

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -4,10 +4,19 @@ cmdignore=(htop tmux top vim)
 # set gt 0 to enable GNU units for time results
 gnuunits=0
 
+# Function taken from undistract-me, get the current window id
+function active_window_id () {
+    if [[ -n $DISPLAY ]] ; then
+        xprop -root _NET_ACTIVE_WINDOW | awk '{print $5}'
+        return
+    fi
+    echo nowindowid
+}
+
 # end and compare timer, notify-send if needed
 function notifyosd-precmd() {
 	retval=$?
-    if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]]; then
+    if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]] || [[ "$cmd_active_win" == "$(active_window_id)" ]]; then
         return
     else
         if [ ! -z "$cmd" ]; then
@@ -52,6 +61,7 @@ function notifyosd-preexec() {
     cmd=$1
     cmd_basename=${${cmd:s/sudo //}[(ws: :)1]} 
     cmd_start=`date +%s`
+    cmd_active_win=$(active_window_id)
 }
 
 # make sure this plays nicely with any existing preexec

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -4,13 +4,34 @@ cmdignore=(htop tmux top vim)
 # set gt 0 to enable GNU units for time results
 gnuunits=0
 
+# Figure out the active Tmux window
+function active_tmux_window() {
+    [ -n "$TMUX" ] || {
+        echo notmux
+        return 1
+    }
+    tmux display-message -p '#W'
+}
+
+function active_tmux_session() {
+    [ -n "$TMUX" ] || {
+        echo notmux
+        return 1
+    }
+    tmux display-message -p '#S'
+}
+
 # Function taken from undistract-me, get the current window id
-function active_window_id () {
+function active_window_id() {
     if [[ -n $DISPLAY ]] ; then
         xprop -root _NET_ACTIVE_WINDOW | awk '{print $5}'
         return
     fi
     echo nowindowid
+}
+
+function is_window_unfocused() {
+    [[ "$cmd_active_win" != $(active_window_id) ]] || [[ "$cmd_tmux_win" != $(active_tmux_window) ]]
 }
 
 # end and compare timer, notify-send if needed
@@ -24,7 +45,7 @@ function notifyosd-precmd() {
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
 
-        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && [[ "$cmd_active_win" != "$(active_window_id)" ]]; then
+        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && is_window_unfocused; then
             if [ $retval -gt 0 ]; then
                 cmdstat="with warning"
                 sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
@@ -42,13 +63,18 @@ function notifyosd-precmd() {
                 cmd_time="$cmd_secs seconds"
             fi
 
+            tmux_info=''
+            if active_tmux_window >/dev/null; then
+                tmux_info="(tmux: $cmd_tmux_session/$cmd_tmux_win)"
+            fi
+
             if [ ! -z $SSH_TTY ] ; then
                 notify-send -i utilities-terminal \
-                        -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time $tmux_info"; \
                         play -q $sndstat
             else
                 notify-send -i utilities-terminal \
-                        -u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        -u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time $tmux_info"; \
                         play -q $sndstat
             fi
         fi
@@ -65,6 +91,8 @@ function notifyosd-preexec() {
     cmd_basename=${${cmd:s/sudo //}[(ws: :)1]} 
     cmd_start=$(date +%s)
     cmd_active_win=$(active_window_id)
+    cmd_tmux_win=$(active_tmux_window)
+    cmd_tmux_session=$(active_tmux_session)
 }
 
 # make sure this plays nicely with any existing preexec

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -1,8 +1,11 @@
+# Default timeout is 10 seconds.
+LONG_RUNNING_COMMAND_TIMEOUT=${LONG_RUNNING_COMMAND_TIMEOUT:-10}
+
+# Set gt 0 to enable GNU units for time results. Disabled by default.
+NOTIFYOSD_GNUUNITS=${NOTIFYOSD_GNUUNITS:-0}
+
 # commands to ignore
 cmdignore=(htop tmux top vim)
-
-# set gt 0 to enable GNU units for time results
-gnuunits=0
 
 # Figure out the active Tmux window
 function active_tmux_window() {
@@ -45,7 +48,7 @@ function notifyosd-precmd() {
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
 
-        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && is_window_unfocused; then
+        if [ ! -z "$cmd" -a $cmd_secs -gt ${LONG_RUNNING_COMMAND_TIMEOUT:-10} ] && is_window_unfocused; then
             if [ $retval -gt 0 ]; then
                 cmdstat="with warning"
                 sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
@@ -56,7 +59,7 @@ function notifyosd-precmd() {
                 urgency="normal"
             fi
 
-            if [ $gnuunits -gt 0 ]; then
+            if [ "$NOTIFYOSD_GNUUNITS" -gt 0 ]; then
                 cmd_time=$(units "$cmd_secs seconds" "centuries;years;months;weeks;days;hours;minutes;seconds" | \
                         sed -e 's/\ +/\,/g' -e s'/\t//')
             else

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -116,7 +116,7 @@ precmd_functions+=( notifyosd-precmd )
 # get command name and start the timer
 function notifyosd-preexec() {
     cmd=$1
-    cmd_basename=${${cmd:s/sudo //}[(ws: :)1]} 
+    cmd_basename=${${cmd:s/sudo //}[(ws: :)1]}
     cmd_start=$(date +%s)
     cmd_active_win=$(active_window_id)
     cmd_tmux_win=$(active_tmux_window)

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -16,29 +16,32 @@ function active_window_id () {
 # end and compare timer, notify-send if needed
 function notifyosd-precmd() {
     retval=$?
-    if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]] || [[ "$cmd_active_win" == "$(active_window_id)" ]]; then
+    if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]]; then
         return
     else
         if [ ! -z "$cmd" ]; then
             cmd_end=$(date +%s)
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
-        if [ $retval -gt 0 ]; then
-            cmdstat="with warning"
-            sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
-            urgency="critical"
-        else
-            cmdstat="successfully"
-            sndstat="/usr/share/sounds/gnome/default/alerts/glass.ogg"
-            urgency="normal"
-        fi
-        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ]; then
+
+        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && [[ "$cmd_active_win" != "$(active_window_id)" ]]; then
+            if [ $retval -gt 0 ]; then
+                cmdstat="with warning"
+                sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
+                urgency="critical"
+            else
+                cmdstat="successfully"
+                sndstat="/usr/share/sounds/gnome/default/alerts/glass.ogg"
+                urgency="normal"
+            fi
+
             if [ $gnuunits -gt 0 ]; then
                 cmd_time=$(units "$cmd_secs seconds" "centuries;years;months;weeks;days;hours;minutes;seconds" | \
                         sed -e 's/\ +/\,/g' -e s'/\t//')
             else
                 cmd_time="$cmd_secs seconds"
             fi
+
             if [ ! -z $SSH_TTY ] ; then
                 notify-send -i utilities-terminal \
                         -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time"; \

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -19,7 +19,7 @@ function active_tmux_window() {
         echo notmux
         return 1
     }
-    tmux display-message -p '#{window_name}'
+    tmux display-message -p '#{window_id}'
 }
 
 function active_tmux_session() {
@@ -27,7 +27,7 @@ function active_tmux_session() {
         echo notmux
         return 1
     }
-    tmux display-message -p '#{session_name}'
+    tmux display-message -p '#{session_id}'
 }
 
 # Function taken from undistract-me, get the current window id
@@ -90,7 +90,7 @@ function notifyosd-precmd() {
 
             tmux_info=''
             if active_tmux_window >/dev/null; then
-                tmux_info=" (tmux: $cmd_tmux_session/$cmd_tmux_win)"
+                tmux_info=" (tmux: $(tmux display-message -p '#{session_name}/#{window_name}'))"
             fi
 
             sshhost_info=''

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -15,38 +15,38 @@ function active_window_id () {
 
 # end and compare timer, notify-send if needed
 function notifyosd-precmd() {
-	retval=$?
+    retval=$?
     if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]] || [[ "$cmd_active_win" == "$(active_window_id)" ]]; then
         return
     else
         if [ ! -z "$cmd" ]; then
-            cmd_end=`date +%s`
+            cmd_end=$(date +%s)
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
         if [ $retval -gt 0 ]; then
-			cmdstat="with warning"
-			sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
-			urgency="critical"
-		else
+            cmdstat="with warning"
+            sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
+            urgency="critical"
+        else
             cmdstat="successfully"
-			sndstat="/usr/share/sounds/gnome/default/alerts/glass.ogg"
-			urgency="normal"
+            sndstat="/usr/share/sounds/gnome/default/alerts/glass.ogg"
+            urgency="normal"
         fi
         if [ ! -z "$cmd" -a $cmd_secs -gt 10 ]; then
-			if [ $gnuunits -gt 0 ]; then
-				cmd_time=$(units "$cmd_secs seconds" "centuries;years;months;weeks;days;hours;minutes;seconds" | \
-						sed -e 's/\ +/\,/g' -e s'/\t//')
-			else
-				cmd_time="$cmd_secs seconds"
-			fi
+            if [ $gnuunits -gt 0 ]; then
+                cmd_time=$(units "$cmd_secs seconds" "centuries;years;months;weeks;days;hours;minutes;seconds" | \
+                        sed -e 's/\ +/\,/g' -e s'/\t//')
+            else
+                cmd_time="$cmd_secs seconds"
+            fi
             if [ ! -z $SSH_TTY ] ; then
                 notify-send -i utilities-terminal \
-						-u $urgency "$cmd_basename on `hostname` completed $cmdstat" "\"$cmd\" took $cmd_time"; \
-						play -q $sndstat
+                        -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        play -q $sndstat
             else
                 notify-send -i utilities-terminal \
-						-u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time"; \
-						play -q $sndstat
+                        -u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        play -q $sndstat
             fi
         fi
         unset cmd
@@ -60,7 +60,7 @@ precmd_functions+=( notifyosd-precmd )
 function notifyosd-preexec() {
     cmd=$1
     cmd_basename=${${cmd:s/sudo //}[(ws: :)1]} 
-    cmd_start=`date +%s`
+    cmd_start=$(date +%s)
     cmd_active_win=$(active_window_id)
 }
 

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -8,10 +8,7 @@ NOTIFYOSD_HUMAN=${NOTIFYOSD_HUMAN:-1}
 UDM_PLAY_SOUND=${UDM_PLAY_SOUND:-0}
 
 # Commands to ignore
-if [ -z "$LONG_RUNNING_IGNORE_LIST" ]
-then
-    LONG_RUNNING_IGNORE_LIST=""
-fi
+# LONG_RUNNING_IGNORE_LIST=()
 
 # Figure out the active Tmux window
 function active_tmux_window() {
@@ -63,7 +60,7 @@ function tohuman {
 # end and compare timer, notify-send if needed
 function notifyosd-precmd() {
     retval=$?
-    if [[ ${cmdignore[(r)$cmd_basename]} == $cmd_basename ]]; then
+    if [[ ${LONG_RUNNING_IGNORE_LIST[(r)$cmd_basename]} == $cmd_basename ]]; then
         return
     else
         if [ ! -z "$cmd" ]; then


### PR DESCRIPTION
Fixes issue #2 . The notification is displayed only when the window in focus is not the one where the long command was running.

I also cleaned up slightly the code, both tabs and spaces were used, so I put spaces everywhere. And using `` ` `` is deprecated so I used `$(..)` instead.
